### PR TITLE
Add more motions

### DIFF
--- a/evil-space.el
+++ b/evil-space.el
@@ -72,12 +72,24 @@
 
 ;;;###autoload
 (defun evil-space-default-setup ()
+  (evil-space-setup "gj" "gj" "gk")
+  (evil-space-setup "gk" "gk" "gj")
+  (evil-space-setup "-" "-" "+")
+  (evil-space-setup "+" "+" "-")
+
+  ;; search motions
   (evil-space-setup "n" "n" "N")
   (evil-space-setup "N" "N" "n")
   (evil-space-setup "t" ";" ",")
   (evil-space-setup "f" ";" ",")
   (evil-space-setup "T" "," ";")
   (evil-space-setup "F" "," ";")
+  (evil-space-setup "*" "*" "#")
+  (evil-space-setup "#" "#" "*")
+
+  ;; block motions
+  (evil-space-setup "(" "(" ")")
+  (evil-space-setup ")" ")" "(")
   (evil-space-setup "{" "{" "}")
   (evil-space-setup "}" "}" "{")
   (evil-space-setup "]]" "]]" "[[")


### PR DESCRIPTION
Hello, I'm working on a similar, but orthogonal, project. I had already compiled a list of motions (and their inverses) that are suitable for repetition.

Here, I've added them to the default config, should you desire to have a more complete collection of motions. If you do not, I would understand as repeating some motions (`h` and `l` for example) makes little sense. However, some of the added motions would be very convenient to repeat. `#` and `*` for example are both very useful, but rather far from the home row, and difficult to repeat.

If you'd like to keep some motions, but not the others, that can be arranged.
