### PR TITLE
Make evil-space-setup accept symbols and forms

### DIFF
--- a/evil-space.el
+++ b/evil-space.el
@@ -60,16 +60,13 @@
 
 (defun evil-space-lookup-key (key &optional keymap)
   "Normalize KEY into a function."
-  (or (if (functionp key) key)
-      (if (symbolp key) (symbol-value key))
-      (if (listp key)
-          (or (ignore-errors (evil-space-lookup-key (eval key)))
-              (error "evil-space: Invalid forms")))
-      (if (stringp key)
-          (if keymap
-              (lookup-key (symbol-value keymap) (kbd key))
-            (lookup-key evil-motion-state-map (kbd key))))
-      (error "evil-space: Could not find key %s" key)))
+  (cond ((eq (car-safe key) 'quote) (cadr key))
+        ((symbolp key) (symbol-value key))
+        ((stringp key)
+         (if keymap
+             (lookup-key (symbol-value keymap) (kbd key))
+           (lookup-key evil-motion-state-map (kbd key))))
+        (t (user-error "Not a valid key: %s" key))))
 
 ;;;###autoload
 (defmacro evil-space-setup (key next prev &optional keymap)

--- a/evil-space.el
+++ b/evil-space.el
@@ -84,7 +84,7 @@ Examples:
          (key-func-next  (or (lookup-key keymap (kbd next))
                              (lookup-key evil-motion-state-map (kbd next))
                              (error "Could not find next key: %s" next)))
-         (key-func-prev  (or (lookup-key keymap (kbd next))
+         (key-func-prev  (or (lookup-key keymap (kbd prev))
                              (lookup-key evil-motion-state-map (kbd prev))
                              (error "Could not find previous key: %s" prev))))
     `(progn


### PR DESCRIPTION
* KEY, NEXT and PREV can now be function symbols or forms that evaluate to a function (as well as a string).
* Now prints error messages if a key can't be found or is invalid.
* Remove fboundp checks so later mappings can override earlier ones.
* Delegates are now named `evil-space--<function name>` instead of `evil-space-<letter>`, e.g. `evil-space--evil-snipe-f`. This removes the possibility of collisions.

For example, these will do the same thing and both will work:

```elisp
(evil-space-setup "f" ";" ",")
(evil-space-setup evil-find-char evil-repeat-find-char evil-repeat-find-char-reverse)
```

(This change was for cases where KEY, NEXT and PREV are in different keymaps)