### PR TITLE
Fix byte-compile issue

### DIFF
--- a/evil-space.el
+++ b/evil-space.el
@@ -60,17 +60,17 @@
     :group 'evil-space)
   (defcustom evil-space-prev-key (kbd "S-SPC")
     "Key that triggers the repeat motion in reverse direction."
-    :group 'evil-space))
+    :group 'evil-space)
 
-(defun evil-space-lookup-key (key &optional keymap)
-  "Normalize KEY into a function."
-  (cond ((eq (car-safe key) 'quote) (cadr key))
-        ((symbolp key) (symbol-value key))
-        ((stringp key)
-         (if keymap
-             (lookup-key (symbol-value keymap) (kbd key))
-           (lookup-key evil-motion-state-map (kbd key))))
-        (t (user-error "Not a valid key: %s" key))))
+  (defun evil-space-lookup-key (key &optional keymap)
+    "Normalize KEY into a function."
+    (cond ((eq (car-safe key) 'quote) (cadr key))
+          ((symbolp key) (symbol-value key))
+          ((stringp key)
+           (if keymap
+               (lookup-key (symbol-value keymap) (kbd key))
+             (lookup-key evil-motion-state-map (kbd key))))
+          (t (user-error "Not a valid key: %s" key)))))
 
 ;;;###autoload
 (defmacro evil-space-setup (key next prev &optional keymap)


### PR DESCRIPTION
Wrap functions with eval-and-compile which are used at compile time. I cannot byte-compile and get following error message.

```
evil-space.el:114:1:Error: Symbol's function definition is void: evil-space-lookup-key
```
